### PR TITLE
Add Streamlit knowledge extractor application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# knowledge_extractor
+# Knowledge Extractor
+
+Application Streamlit permettant de centraliser un corpus documentaire et de générer des fiches de révision et des résumés au format PDF.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Lancement
+
+```bash
+streamlit run streamlit_app.py
+```
+
+## Fonctionnalités principales
+
+- Ingestion de documents depuis des fichiers (`.txt`, `.md`, `.rtf`, `.docx`, `.pdf`), du texte libre ou des pages web.
+- Stockage des documents dans une base SQLite locale.
+- Génération automatique de résumés et export en PDF.
+- Création de fiches de révision structurées en quatre sections, exportées en PDF et mises à jour lorsque le corpus évolue.
+- Génération de rapports CSV listant les fiches de révision et les résumés disponibles.
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for the knowledge extractor Streamlit application."""

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,211 @@
+"""Database utilities for the knowledge extractor application."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+DB_PATH = Path("data/app.db")
+
+
+def ensure_database(base_dir: Path) -> None:
+    """Ensure that the sqlite database and required tables exist."""
+    db_path = base_dir / DB_PATH
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                source_path TEXT,
+                url TEXT,
+                text_content TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS summaries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                document_id INTEGER NOT NULL UNIQUE,
+                summary TEXT NOT NULL,
+                pdf_path TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY(document_id) REFERENCES documents(id) ON DELETE CASCADE
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS revision_sheets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                theme TEXT NOT NULL UNIQUE,
+                content TEXT NOT NULL,
+                pdf_path TEXT NOT NULL,
+                sources TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+
+
+@contextmanager
+def get_connection(base_dir: Path):
+    """Context manager yielding a sqlite connection."""
+    db_path = base_dir / DB_PATH
+    conn = sqlite3.connect(db_path)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def insert_document(
+    base_dir: Path,
+    *,
+    title: str,
+    source_type: str,
+    source_path: Optional[str],
+    url: Optional[str],
+    text_content: str,
+) -> int:
+    with get_connection(base_dir) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO documents (title, source_type, source_path, url, text_content)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (title, source_type, source_path, url, text_content),
+        )
+        conn.commit()
+        return cursor.lastrowid
+
+
+def fetch_documents(base_dir: Path) -> List[Dict[str, Any]]:
+    with get_connection(base_dir) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, title, source_type, source_path, url, text_content,
+                   created_at, updated_at
+            FROM documents
+            ORDER BY created_at DESC
+            """
+        )
+        rows = cursor.fetchall()
+    columns = ["id", "title", "source_type", "source_path", "url", "text_content", "created_at", "updated_at"]
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def fetch_document(base_dir: Path, document_id: int) -> Optional[Dict[str, Any]]:
+    with get_connection(base_dir) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, title, source_type, source_path, url, text_content,
+                   created_at, updated_at
+            FROM documents WHERE id = ?
+            """,
+            (document_id,),
+        )
+        row = cursor.fetchone()
+    if not row:
+        return None
+    columns = ["id", "title", "source_type", "source_path", "url", "text_content", "created_at", "updated_at"]
+    return dict(zip(columns, row))
+
+
+def upsert_summary(
+    base_dir: Path,
+    *,
+    document_id: int,
+    summary: str,
+    pdf_path: str,
+) -> None:
+    with get_connection(base_dir) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO summaries (document_id, summary, pdf_path)
+            VALUES (?, ?, ?)
+            ON CONFLICT(document_id) DO UPDATE SET
+                summary=excluded.summary,
+                pdf_path=excluded.pdf_path,
+                updated_at=CURRENT_TIMESTAMP
+            """,
+            (document_id, summary, pdf_path),
+        )
+        conn.commit()
+
+
+def fetch_summaries(base_dir: Path) -> List[Dict[str, Any]]:
+    with get_connection(base_dir) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT document_id, summary, pdf_path, created_at, updated_at
+            FROM summaries
+            """
+        )
+        rows = cursor.fetchall()
+    columns = ["document_id", "summary", "pdf_path", "created_at", "updated_at"]
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def upsert_revision_sheet(
+    base_dir: Path,
+    *,
+    theme: str,
+    content: str,
+    pdf_path: str,
+    sources: Iterable[str],
+) -> None:
+    with get_connection(base_dir) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO revision_sheets (theme, content, pdf_path, sources)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(theme) DO UPDATE SET
+                content=excluded.content,
+                pdf_path=excluded.pdf_path,
+                sources=excluded.sources,
+                updated_at=CURRENT_TIMESTAMP
+            """,
+            (theme, content, pdf_path, json.dumps(list(sources))),
+        )
+        conn.commit()
+
+
+def fetch_revision_sheets(base_dir: Path) -> List[Dict[str, Any]]:
+    with get_connection(base_dir) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT theme, content, pdf_path, sources, created_at, updated_at
+            FROM revision_sheets
+            ORDER BY updated_at DESC
+            """
+        )
+        rows = cursor.fetchall()
+    columns = ["theme", "content", "pdf_path", "sources", "created_at", "updated_at"]
+    result = []
+    for row in rows:
+        record = dict(zip(columns, row))
+        record["sources"] = json.loads(record["sources"])
+        result.append(record)
+    return result
+
+

--- a/app/ingestion.py
+++ b/app/ingestion.py
@@ -1,0 +1,102 @@
+"""Document ingestion utilities."""
+
+from __future__ import annotations
+
+import mimetypes
+import re
+import textwrap
+from pathlib import Path
+from typing import Optional, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+from docx import Document
+from PyPDF2 import PdfReader
+
+
+TEXT_EXTENSIONS = {".txt", ".md", ".rtf"}
+DOCX_EXTENSIONS = {".docx"}
+PDF_EXTENSIONS = {".pdf"}
+
+
+class IngestionError(RuntimeError):
+    """Raised when a document cannot be ingested."""
+
+
+def normalise_title(value: str) -> str:
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    return cleaned or "Document sans titre"
+
+
+def save_uploaded_file(base_dir: Path, file_name: str, data: bytes) -> Path:
+    target_dir = base_dir / "data" / "corpus" / "originals"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / file_name
+    with open(target_path, "wb") as f:
+        f.write(data)
+    return target_path
+
+
+def extract_text_from_path(path: Path) -> str:
+    extension = path.suffix.lower()
+    if extension in TEXT_EXTENSIONS:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    if extension in DOCX_EXTENSIONS:
+        doc = Document(path)
+        return "\n".join(paragraph.text for paragraph in doc.paragraphs)
+    if extension in PDF_EXTENSIONS:
+        reader = PdfReader(str(path))
+        pages = [page.extract_text() or "" for page in reader.pages]
+        return "\n".join(pages)
+    raise IngestionError(f"Format de fichier non supporté : {extension}")
+
+
+def guess_extension_from_mime(mime_type: Optional[str]) -> str:
+    if not mime_type:
+        return ""
+    extension = mimetypes.guess_extension(mime_type)
+    return extension or ""
+
+
+def ingest_uploaded_file(
+    base_dir: Path, *, file_name: str, data: bytes, mime_type: Optional[str]
+) -> Tuple[str, str, Path]:
+    extension = Path(file_name).suffix
+    if not extension:
+        extension = guess_extension_from_mime(mime_type)
+        if extension:
+            file_name = f"{file_name}{extension}"
+    saved_path = save_uploaded_file(base_dir, file_name, data)
+    text_content = extract_text_from_path(saved_path)
+    title = normalise_title(Path(file_name).stem.replace("_", " "))
+    return title, text_content, saved_path
+
+
+def ingest_text_input(text: str, *, title: Optional[str] = None) -> Tuple[str, str]:
+    cleaned = textwrap.dedent(text).strip()
+    if not cleaned:
+        raise IngestionError("Le texte fourni est vide.")
+    final_title = normalise_title(title or cleaned.splitlines()[0][:80])
+    return final_title, cleaned
+
+
+def ingest_url(base_dir: Path, url: str) -> Tuple[str, str, Path]:
+    response = requests.get(url, timeout=10)
+    if response.status_code != 200:
+        raise IngestionError(f"Impossible de récupérer l'URL : {response.status_code}")
+    soup = BeautifulSoup(response.content, "html.parser")
+    title = soup.title.string if soup.title else url
+    texts = [element.get_text(separator=" ", strip=True) for element in soup.find_all(["p", "li", "h1", "h2", "h3", "h4", "h5", "h6"]) ]
+    content = "\n".join(filter(None, texts))
+    if not content.strip():
+        content = BeautifulSoup(response.content, "html.parser").get_text(separator=" ", strip=True)
+    if not content.strip():
+        raise IngestionError("Le contenu de la page est vide.")
+    final_title = normalise_title(title)
+    storage_dir = base_dir / "data" / "corpus" / "web"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = re.sub(r"[^a-zA-Z0-9_-]", "_", final_title)[:80]
+    target_path = storage_dir / f"{safe_name}.html"
+    target_path.write_bytes(response.content)
+    return final_title, content, target_path
+

--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,0 +1,49 @@
+"""PDF export helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from fpdf import FPDF
+
+
+class PDFDocument(FPDF):
+    def header(self) -> None:  # pragma: no cover - layout only
+        self.set_font("Helvetica", "B", 12)
+        self.cell(0, 10, self.title, ln=True, align="C")
+        self.ln(5)
+
+
+def write_multiline(pdf: PDFDocument, text: str, *, font_size: int = 11) -> None:
+    pdf.set_font("Helvetica", size=font_size)
+    pdf.multi_cell(0, 8, txt=text)
+    pdf.ln(2)
+
+
+def save_revision_pdf(base_dir: Path, theme: str, markdown: str) -> Path:
+    pdf_dir = base_dir / "data" / "revision_sheets"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = theme.replace("/", "-").replace(" ", "_")
+    target_path = pdf_dir / f"{safe_name}.pdf"
+    pdf = PDFDocument()
+    pdf.set_title(theme)
+    pdf.add_page()
+    for block in markdown.split("\n\n"):
+        write_multiline(pdf, block)
+    pdf.output(str(target_path))
+    return target_path
+
+
+def save_summary_pdf(base_dir: Path, title: str, content: str) -> Path:
+    pdf_dir = base_dir / "data" / "summaries"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = title.replace("/", "-").replace(" ", "_")
+    target_path = pdf_dir / f"{safe_name}.pdf"
+    pdf = PDFDocument()
+    pdf.set_title(title)
+    pdf.add_page()
+    write_multiline(pdf, content)
+    pdf.output(str(target_path))
+    return target_path
+

--- a/app/reports.py
+++ b/app/reports.py
@@ -1,0 +1,42 @@
+"""Reporting utilities for revision sheets and summaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Mapping
+
+import pandas as pd
+
+
+REVISION_REPORT = Path("data/reports/revision_sheets_overview.csv")
+SUMMARY_REPORT = Path("data/reports/document_summaries_overview.csv")
+
+
+def ensure_reports_dir(base_dir: Path) -> None:
+    report_dir = base_dir / "data" / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+
+def update_revision_report(base_dir: Path, entries: Iterable[Mapping[str, str]]) -> Path:
+    ensure_reports_dir(base_dir)
+    report_path = base_dir / REVISION_REPORT
+    data = list(entries)
+    if data:
+        df = pd.DataFrame(data)
+    else:
+        df = pd.DataFrame(columns=["theme", "pdf_path", "sources", "last_updated"])
+    df.to_csv(report_path, index=False)
+    return report_path
+
+
+def update_summary_report(base_dir: Path, entries: Iterable[Mapping[str, str]]) -> Path:
+    ensure_reports_dir(base_dir)
+    report_path = base_dir / SUMMARY_REPORT
+    data = list(entries)
+    if data:
+        df = pd.DataFrame(data)
+    else:
+        df = pd.DataFrame(columns=["document_id", "document_title", "summary_pdf", "last_updated"])
+    df.to_csv(report_path, index=False)
+    return report_path
+

--- a/app/revision.py
+++ b/app/revision.py
@@ -1,0 +1,131 @@
+"""Revision sheet generation logic."""
+
+from __future__ import annotations
+
+import random
+import re
+from dataclasses import dataclass
+from typing import List, Sequence
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from .summarization import summarise_documents
+
+
+@dataclass
+class RevisionSheet:
+    theme: str
+    synthesis: str
+    sources: List[str]
+    bibliography: List[str]
+    essay_topics: List[str]
+
+    def to_markdown(self) -> str:
+        lines = [f"# {self.theme}", "", "## 1. Synthèse", self.synthesis or "(Synthèse indisponible)"]
+        lines.extend(["", "## 2. Sources du corpus"])
+        if self.sources:
+            lines.extend([f"- {source}" for source in self.sources])
+        else:
+            lines.append("- Aucune source identifiée")
+        lines.extend(["", "## 3. Références bibliographiques"])
+        if self.bibliography:
+            lines.extend([f"- {ref}" for ref in self.bibliography])
+        else:
+            lines.append("- Aucune référence disponible")
+        lines.extend(["", "## 4. Sujets possibles"])
+        lines.extend([f"- {topic}" for topic in self.essay_topics])
+        return "\n".join(lines)
+
+
+class RevisionGenerator:
+    """Generate revision sheets from a corpus."""
+
+    def __init__(self) -> None:
+        self.vectorizer = TfidfVectorizer(stop_words="english", max_features=5000)
+
+    def select_relevant_documents(
+        self, theme: str, documents: Sequence[dict], max_docs: int = 8
+    ) -> List[dict]:
+        if not documents:
+            return []
+        corpus_texts = [doc["text_content"] for doc in documents]
+        tfidf_matrix = self.vectorizer.fit_transform(corpus_texts + [theme])
+        theme_vector = tfidf_matrix[-1]
+        doc_vectors = tfidf_matrix[:-1]
+        similarities = cosine_similarity(doc_vectors, theme_vector)
+        indexed = list(enumerate(similarities.flatten()))
+        ranked = sorted(indexed, key=lambda item: item[1], reverse=True)
+        selected_indices = [index for index, score in ranked[:max_docs] if score > 0]
+        return [documents[i] for i in selected_indices]
+
+    def build_synthesis(self, theme: str, docs: Sequence[dict]) -> str:
+        contents = [doc["text_content"] for doc in docs]
+        if not contents:
+            return ""
+        summary = summarise_documents(contents, max_sentences=12)
+        return summary or f"Aucune synthèse disponible pour {theme}."
+
+    def extract_bibliographic_references(self, docs: Sequence[dict]) -> List[str]:
+        references: List[str] = []
+        for doc in docs:
+            lines = re.split(r"[\n\r]", doc["text_content"])
+            for line in lines:
+                cleaned = line.strip()
+                if len(cleaned) < 40:
+                    continue
+                if re.search(r"(19|20)\d{2}", cleaned) or "doi" in cleaned.lower():
+                    references.append(cleaned)
+        unique_refs = list(dict.fromkeys(references))
+        return unique_refs[:6]
+
+    def fetch_external_references(self, theme: str, limit: int = 3) -> List[str]:
+        try:
+            import wikipedia
+
+            wikipedia.set_lang("fr")
+            search_results = wikipedia.search(theme, results=limit)
+            external_refs = []
+            for result in search_results:
+                try:
+                    page = wikipedia.page(result, auto_suggest=False)
+                    external_refs.append(f"{page.title} — {page.url}")
+                except Exception:  # pragma: no cover - best effort
+                    continue
+            return external_refs
+        except Exception:
+            templates = [
+                f"Exploration complémentaire : encyclopédie ou bases de données académiques sur '{theme}'.",
+                f"Articles de revues spécialisées consacrées à '{theme}'.",
+                f"Rapports institutionnels récents traitant de '{theme}'.",
+            ]
+            return templates[:limit]
+
+    def format_bibliography(self, internal_refs: Sequence[str], external_refs: Sequence[str]) -> List[str]:
+        bibliography: List[str] = []
+        for ref in internal_refs:
+            bibliography.append(f"**{ref}** (Corpus)")
+        bibliography.extend(ref for ref in external_refs if ref)
+        return bibliography[:8]
+
+    def generate_topics(self, theme: str) -> List[str]:
+        templates = [
+            "Analysez les enjeux historiques, économiques et sociaux liés à {theme}.",
+            "Discutez des débats théoriques majeurs entourant {theme}.",
+            "Proposez une étude comparative mettant en perspective {theme} et un autre cas d'étude.",
+            "Évaluez l'impact des politiques publiques sur {theme}.",
+            "Expliquez comment {theme} transforme les pratiques contemporaines.",
+        ]
+        random.seed(theme)
+        selected = random.sample(templates, k=3)
+        return [template.format(theme=theme) for template in selected]
+
+    def create_revision_sheet(self, theme: str, documents: Sequence[dict]) -> RevisionSheet:
+        selected_docs = self.select_relevant_documents(theme, documents)
+        synthesis = self.build_synthesis(theme, selected_docs)
+        sources = [doc["title"] for doc in selected_docs]
+        internal_refs = self.extract_bibliographic_references(selected_docs)
+        external_refs = self.fetch_external_references(theme)
+        bibliography = self.format_bibliography(internal_refs, external_refs)
+        topics = self.generate_topics(theme)
+        return RevisionSheet(theme, synthesis, sources, bibliography, topics)
+

--- a/app/services.py
+++ b/app/services.py
@@ -1,0 +1,111 @@
+"""High level services orchestrating ingestion, revision sheets and summaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from . import db
+from .pdf_utils import save_revision_pdf, save_summary_pdf
+from .reports import update_revision_report, update_summary_report
+from .revision import RevisionGenerator
+from .summarization import summarise_text
+
+
+class KnowledgeService:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+        db.ensure_database(base_dir)
+        self.revision_generator = RevisionGenerator()
+
+    # Document operations -------------------------------------------------
+    def add_document(self, *, title: str, source_type: str, source_path: Optional[str], url: Optional[str], text_content: str) -> int:
+        document_id = db.insert_document(
+            self.base_dir,
+            title=title,
+            source_type=source_type,
+            source_path=source_path,
+            url=url,
+            text_content=text_content,
+        )
+        # Regenerate previously saved revision sheets to include the new document
+        self.regenerate_saved_revision_sheets()
+        return document_id
+
+    def list_documents(self) -> List[Dict]:
+        return db.fetch_documents(self.base_dir)
+
+    def get_document(self, document_id: int) -> Optional[Dict]:
+        return db.fetch_document(self.base_dir, document_id)
+
+    # Summaries -----------------------------------------------------------
+    def build_summary(self, document_id: int, max_sentences: int = 12) -> Optional[str]:
+        document = self.get_document(document_id)
+        if not document:
+            return None
+        text = document["text_content"]
+        summary = summarise_text(text, max_sentences=max_sentences)
+        if not summary:
+            summary = text[:2000]
+        pdf_path = save_summary_pdf(self.base_dir, document["title"], summary)
+        db.upsert_summary(self.base_dir, document_id=document_id, summary=summary, pdf_path=str(pdf_path))
+        self.refresh_summary_report()
+        return summary
+
+    def refresh_summary_report(self) -> None:
+        summaries = db.fetch_summaries(self.base_dir)
+        documents = {doc["id"]: doc for doc in self.list_documents()}
+        entries = []
+        for summary in summaries:
+            document = documents.get(summary["document_id"])
+            if not document:
+                continue
+            entries.append(
+                {
+                    "document_id": summary["document_id"],
+                    "document_title": document["title"],
+                    "summary_pdf": summary["pdf_path"],
+                    "last_updated": summary["updated_at"],
+                }
+            )
+        update_summary_report(self.base_dir, entries)
+
+    # Revision sheets -----------------------------------------------------
+    def generate_revision_sheet(self, theme: str) -> Optional[str]:
+        documents = self.list_documents()
+        if not documents:
+            return None
+        sheet = self.revision_generator.create_revision_sheet(theme, documents)
+        markdown = sheet.to_markdown()
+        pdf_path = save_revision_pdf(self.base_dir, theme, markdown)
+        db.upsert_revision_sheet(
+            self.base_dir,
+            theme=theme,
+            content=markdown,
+            pdf_path=str(pdf_path),
+            sources=sheet.sources,
+        )
+        self.refresh_revision_report()
+        return markdown
+
+    def regenerate_saved_revision_sheets(self) -> None:
+        saved_sheets = db.fetch_revision_sheets(self.base_dir)
+        if not saved_sheets:
+            return
+        for sheet in saved_sheets:
+            self.generate_revision_sheet(sheet["theme"])
+
+    def refresh_revision_report(self) -> None:
+        sheets = db.fetch_revision_sheets(self.base_dir)
+        entries = []
+        for sheet in sheets:
+            entries.append(
+                {
+                    "theme": sheet["theme"],
+                    "pdf_path": sheet["pdf_path"],
+                    "sources": ", ".join(sheet["sources"]),
+                    "last_updated": sheet["updated_at"],
+                }
+            )
+        update_revision_report(self.base_dir, entries)
+

--- a/app/summarization.py
+++ b/app/summarization.py
@@ -1,0 +1,67 @@
+"""Text summarisation helpers."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Iterable, List
+
+import nltk
+
+
+def ensure_nltk_resources() -> None:
+    try:
+        nltk.data.find("tokenizers/punkt")
+    except LookupError:
+        nltk.download("punkt")
+    try:
+        nltk.data.find("corpora/stopwords")
+    except LookupError:
+        nltk.download("stopwords")
+
+
+def sentence_tokenize(text: str) -> List[str]:
+    ensure_nltk_resources()
+    sentences = nltk.sent_tokenize(text)
+    return [sentence.strip() for sentence in sentences if sentence.strip()]
+
+
+def word_tokenize(text: str) -> List[str]:
+    ensure_nltk_resources()
+    tokens = nltk.word_tokenize(text)
+    return [token.lower() for token in tokens if re.search(r"[\wÀ-ÿ]", token)]
+
+
+def summarise_text(text: str, max_sentences: int = 10) -> str:
+    sentences = sentence_tokenize(text)
+    if len(sentences) <= max_sentences:
+        return " ".join(sentences)
+    words = word_tokenize(text)
+    if not words:
+        return ""
+    stopwords = set(nltk.corpus.stopwords.words("french")) | set(nltk.corpus.stopwords.words("english"))
+    word_freq = Counter(word for word in words if word not in stopwords)
+    if not word_freq:
+        return ""
+    max_freq = max(word_freq.values())
+    for word in list(word_freq):
+        word_freq[word] /= max_freq
+    sentence_scores = {}
+    for sentence in sentences:
+        sentence_words = word_tokenize(sentence)
+        if not sentence_words:
+            continue
+        score = sum(word_freq.get(word, 0.0) for word in sentence_words)
+        sentence_scores[sentence] = score / math.sqrt(len(sentence_words))
+    ranked_sentences = sorted(sentence_scores.items(), key=lambda item: item[1], reverse=True)
+    selected = sorted((sentence for sentence, _ in ranked_sentences[:max_sentences]), key=lambda s: sentences.index(s))
+    return " ".join(selected)
+
+
+def summarise_documents(doc_texts: Iterable[str], max_sentences: int = 10) -> str:
+    combined = "\n".join(text.strip() for text in doc_texts if text.strip())
+    if not combined:
+        return ""
+    return summarise_text(combined, max_sentences=max_sentences)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+streamlit
+pandas
+numpy
+scikit-learn
+nltk
+requests
+beautifulsoup4
+python-docx
+PyPDF2
+fpdf2
+wikipedia

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,182 @@
+"""Streamlit interface for the knowledge extractor application."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import List, Optional
+
+import pandas as pd
+import streamlit as st
+
+from app import db
+from app.ingestion import IngestionError, ingest_text_input, ingest_uploaded_file, ingest_url
+from app.services import KnowledgeService
+
+BASE_DIR = Path(__file__).parent
+
+
+@st.cache_resource(show_spinner=False)
+def get_service() -> KnowledgeService:
+    return KnowledgeService(BASE_DIR)
+
+
+def corpus_management_page(service: KnowledgeService) -> None:
+    st.header("Gestion du corpus")
+    st.markdown(
+        "Ajoutez des documents au corpus en téléchargeant un fichier, en collant un texte ou en fournissant une URL."
+    )
+    tab_file, tab_text, tab_url = st.tabs(["Fichier", "Texte", "URL"])
+
+    with tab_file:
+        uploaded = st.file_uploader("Téléverser un document", type=["txt", "md", "rtf", "docx", "pdf"])
+        if uploaded is not None and st.button("Ajouter le fichier", key="add_file"):
+            try:
+                title, text, saved_path = ingest_uploaded_file(
+                    BASE_DIR,
+                    file_name=uploaded.name,
+                    data=uploaded.getvalue(),
+                    mime_type=uploaded.type,
+                )
+                service.add_document(
+                    title=title,
+                    source_type="fichier",
+                    source_path=str(saved_path),
+                    url=None,
+                    text_content=text,
+                )
+                st.success(f"Document '{title}' ajouté au corpus.")
+            except IngestionError as error:
+                st.error(str(error))
+
+    with tab_text:
+        title = st.text_input("Titre (optionnel)")
+        text_content = st.text_area("Contenu du document")
+        if st.button("Ajouter le texte", key="add_text"):
+            try:
+                final_title, text = ingest_text_input(text_content, title=title or None)
+                service.add_document(
+                    title=final_title,
+                    source_type="texte",
+                    source_path=None,
+                    url=None,
+                    text_content=text,
+                )
+                st.success(f"Document '{final_title}' ajouté au corpus.")
+            except IngestionError as error:
+                st.error(str(error))
+
+    with tab_url:
+        url = st.text_input("Adresse URL")
+        if st.button("Ajouter la page web", key="add_url") and url:
+            try:
+                title, text, saved_path = ingest_url(BASE_DIR, url)
+                service.add_document(
+                    title=title,
+                    source_type="url",
+                    source_path=str(saved_path),
+                    url=url,
+                    text_content=text,
+                )
+                st.success(f"Document '{title}' provenant de l'URL ajouté au corpus.")
+            except IngestionError as error:
+                st.error(str(error))
+
+    st.subheader("Documents disponibles")
+    documents = service.list_documents()
+    if not documents:
+        st.info("Aucun document enregistré pour le moment.")
+        return
+    for document in documents:
+        with st.expander(document["title"], expanded=False):
+            st.write(f"**Source :** {document['source_type']}")
+            if document.get("url"):
+                st.write(f"**URL :** {document['url']}")
+            st.write(document["text_content"][:500] + ("…" if len(document["text_content"]) > 500 else ""))
+            if st.button("Générer / mettre à jour le résumé", key=f"summary_{document['id']}"):
+                summary = service.build_summary(document["id"])
+                if summary:
+                    st.success("Résumé enregistré et exporté en PDF.")
+                else:
+                    st.warning("Impossible de générer le résumé.")
+
+
+def revision_sheet_page(service: KnowledgeService) -> None:
+    st.header("Fiches de révision")
+    theme = st.text_input("Thématique à réviser")
+    if st.button("Générer la fiche", key="generate_sheet"):
+        if not theme:
+            st.warning("Veuillez saisir une thématique.")
+        else:
+            markdown = service.generate_revision_sheet(theme)
+            if not markdown:
+                st.warning("Aucun document dans le corpus pour générer une fiche.")
+            else:
+                st.success("Fiche générée et enregistrée en PDF.")
+                st.markdown(markdown)
+
+    st.subheader("Fiches enregistrées")
+    sheets = db.fetch_revision_sheets(BASE_DIR)
+    if sheets:
+        for sheet in sheets:
+            with st.expander(sheet["theme"], expanded=False):
+                st.markdown(sheet["content"])
+                st.caption(f"PDF : {sheet['pdf_path']}")
+    else:
+        st.info("Aucune fiche enregistrée pour le moment.")
+
+
+def summaries_page(service: KnowledgeService) -> None:
+    st.header("Résumés des documents")
+    summaries = db.fetch_summaries(BASE_DIR)
+    documents = {doc["id"]: doc for doc in service.list_documents()}
+    if not summaries:
+        st.info("Aucun résumé généré pour le moment.")
+        return
+    for summary in summaries:
+        document = documents.get(summary["document_id"])
+        if not document:
+            continue
+        with st.expander(document["title"], expanded=False):
+            st.write(summary["summary"])
+            st.caption(f"PDF : {summary['pdf_path']}")
+
+
+def reports_page() -> None:
+    st.header("Rapports de suivi")
+    revision_report = BASE_DIR / "data" / "reports" / "revision_sheets_overview.csv"
+    summary_report = BASE_DIR / "data" / "reports" / "document_summaries_overview.csv"
+
+    if revision_report.exists():
+        st.subheader("Fiches de révision")
+        df_revision = pd.read_csv(revision_report)
+        st.dataframe(df_revision)
+    else:
+        st.info("Aucun rapport de fiches de révision disponible.")
+
+    if summary_report.exists():
+        st.subheader("Résumés")
+        df_summary = pd.read_csv(summary_report)
+        st.dataframe(df_summary)
+    else:
+        st.info("Aucun rapport de résumés disponible.")
+
+
+def main() -> None:
+    st.set_page_config(page_title="Knowledge Extractor", layout="wide")
+    service = get_service()
+
+    menu = {
+        "Gestion du corpus": corpus_management_page,
+        "Fiches de révision": revision_sheet_page,
+        "Résumés": summaries_page,
+        "Rapports": lambda service: reports_page(),
+    }
+    choice = st.sidebar.radio("Navigation", list(menu.keys()))
+    page = menu[choice]
+    page(service)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a Streamlit interface to ingest corpus documents, generate revision sheets, and manage summaries
- implement services for SQLite persistence, PDF exports, revision generation, and reporting
- document setup instructions and declare runtime dependencies

## Testing
- python -m compileall app streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e0e0e4d2448326ada54f7562dfcd1f