### PR TITLE
Handle locked PDF exports with fallback file naming

### DIFF
--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import base64
 import gzip
+import logging
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 from fpdf import FPDF
 
 from .assets.dejavu_sans_data import DEJAVU_SANS_BOLD, DEJAVU_SANS_REGULAR
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class PDFDocument(FPDF):
@@ -53,28 +58,77 @@ def write_multiline(pdf: PDFDocument, text: str, *, font_size: int = 11) -> None
     pdf.ln(2)
 
 
-def save_revision_pdf(base_dir: Path, theme: str, markdown: str) -> Path:
+def write_pdf_with_fallback(pdf: FPDF, target: Path) -> Path:
+    """Write ``pdf`` to ``target`` with a rename fallback when locked."""
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    suffix = target.suffix or ".pdf"
+    with tempfile.NamedTemporaryFile(delete=False, dir=target.parent, suffix=suffix) as tmp_file:
+        temp_path = Path(tmp_file.name)
+
+    try:
+        pdf.output(str(temp_path))
+    except Exception:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise
+
+    try:
+        temp_path.replace(target)
+        return target
+    except PermissionError:
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        candidate = target.with_name(f"{target.stem}_{timestamp}{suffix}")
+        counter = 1
+        while candidate.exists():
+            candidate = target.with_name(f"{target.stem}_{timestamp}_{counter}{suffix}")
+            counter += 1
+        temp_path.replace(candidate)
+        return candidate
+
+
+def save_revision_pdf(
+    base_dir: Path, theme: str, markdown: str, previous_path: Path | None = None
+) -> Path:
     pdf_dir = base_dir / "data" / "revision_sheets"
     pdf_dir.mkdir(parents=True, exist_ok=True)
     safe_name = theme.replace("/", "-").replace(" ", "_")
     target_path = pdf_dir / f"{safe_name}.pdf"
+    previous_target = Path(previous_path) if previous_path else None
     pdf = PDFDocument()
     pdf.set_title(theme)
     pdf.add_page()
     for block in markdown.split("\n\n"):
         write_multiline(pdf, block)
-    pdf.output(str(target_path))
-    return target_path
+    written_path = write_pdf_with_fallback(pdf, target_path)
+    if written_path != target_path:
+        LOGGER.warning(
+            "Impossible d'écraser le fichier PDF cible %s (ancien fichier %s). Nouveau fichier enregistré sous %s.",
+            target_path,
+            previous_target or target_path,
+            written_path,
+        )
+    return written_path
 
 
-def save_summary_pdf(base_dir: Path, title: str, content: str) -> Path:
+def save_summary_pdf(
+    base_dir: Path, title: str, content: str, previous_path: Path | None = None
+) -> Path:
     pdf_dir = base_dir / "data" / "summaries"
     pdf_dir.mkdir(parents=True, exist_ok=True)
     safe_name = title.replace("/", "-").replace(" ", "_")
     target_path = pdf_dir / f"{safe_name}.pdf"
+    previous_target = Path(previous_path) if previous_path else None
     pdf = PDFDocument()
     pdf.set_title(title)
     pdf.add_page()
     write_multiline(pdf, content)
-    pdf.output(str(target_path))
-    return target_path
+    written_path = write_pdf_with_fallback(pdf, target_path)
+    if written_path != target_path:
+        LOGGER.warning(
+            "Impossible d'écraser le fichier PDF cible %s (ancien fichier %s). Nouveau fichier enregistré sous %s.",
+            target_path,
+            previous_target or target_path,
+            written_path,
+        )
+    return written_path


### PR DESCRIPTION
## Summary
- add a write_pdf_with_fallback helper that writes via a temporary file and renames into place, falling back to a timestamped name when the target is locked
- update the PDF saving helpers to return the actual written path and log when a fallback name was needed
- update KnowledgeService to pass previous PDF paths, clean up obsolete files when possible, and warn Streamlit users when a locked file prevented replacement

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e2401e3ebc8326a15b872404b54d0e