### PR TITLE
Handle multilingual stopwords for revision selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ streamlit run streamlit_app.py
 - Création de fiches de révision structurées en quatre sections, exportées en PDF et mises à jour lorsque le corpus évolue.
 - Génération de rapports CSV listant les fiches de révision et les résumés disponibles.
 
+## Considérations linguistiques
+
+- La sélection de documents pertinents utilise un vocabulaire filtré qui fusionne les stopwords anglais et français fournis par
+  NLTK. En l'absence des corpus téléchargés, des listes de secours sont appliquées pour éviter de favoriser un seul ensemble
+  linguistique.
+- Pour intégrer d'autres langues, ajoutez les listes de mots vides correspondantes lors du prétraitement (via NLTK ou des listes
+  dédiées) afin d'équilibrer la pondération TF-IDF lors de l'ingestion.
+
 ## Polices PDF intégrées
 
 Les exports PDF utilisent la police Unicode **DejaVu Sans** pour éviter les erreurs

--- a/tests/test_revision.py
+++ b/tests/test_revision.py
@@ -140,3 +140,33 @@ def test_fallback_bullets_are_full_sentences(monkeypatch):
         assert bullet.startswith("- ")
         assert not bullet.endswith("…")
         assert bullet.rstrip().endswith((".", "!", "?"))
+
+
+def test_document_selection_handles_multilingual_stopwords():
+    generator = RevisionGenerator()
+
+    documents = [
+        {
+            "title": "Transition énergétique",
+            "text_content": (
+                "La transition énergétique et le climat exigent des politiques publiques "
+                "ambitieuses pour réduire les émissions et transformer les infrastructures."
+            ),
+        },
+        {
+            "title": "Renaissance artistique",
+            "text_content": (
+                "The renaissance art movement highlighted perspective, humanism, and the "
+                "rediscovery of classical knowledge across Europe."
+            ),
+        },
+    ]
+
+    french_theme = "La transition énergétique face au climat"
+    english_theme = "Humanism within the renaissance art perspective"
+
+    selected_french = generator.select_relevant_documents(french_theme, documents, max_docs=1)
+    assert selected_french and selected_french[0]["title"] == "Transition énergétique"
+
+    selected_english = generator.select_relevant_documents(english_theme, documents, max_docs=1)
+    assert selected_english and selected_english[0]["title"] == "Renaissance artistique"


### PR DESCRIPTION
## Summary
- merge English and French stopword lists (with fallbacks) when vectorizing revision documents
- add a regression test ensuring multilingual themes select the appropriate source
- document how to extend the stopword handling for additional languages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e29a27654c8326abefb5937f387e5d